### PR TITLE
fix: exclude Persian and Arabic-Indic digits from direction voting

### DIFF
--- a/src/lib/text-direction.test.ts
+++ b/src/lib/text-direction.test.ts
@@ -19,3 +19,19 @@ test('keeps the fallback while the draft has no letters yet', () => {
   assert.equal(detectTextDirection('  ۱۲۳ …'), 'rtl')
   assert.equal(detectTextDirection('123', 'ltr'), 'ltr')
 })
+
+test('does not count Persian or Arabic-Indic digits as directional words', () => {
+  for (const digits of ['123 456', '۱۲۳ ۴۵۶', '١٢٣ ٤٥٦']) {
+    assert.equal(detectTextDirection(`Hello ${digits}`), 'ltr')
+    assert.equal(detectTextDirection(`سلام ${digits}`, 'ltr'), 'rtl')
+    assert.equal(detectTextDirection(digits, 'ltr'), 'ltr')
+    assert.equal(detectTextDirection(digits, 'rtl'), 'rtl')
+  }
+})
+
+test("does not let attached numerals outweigh a word's letters", () => {
+  assert.equal(detectTextDirection('API۱۲۳۴'), 'ltr')
+  assert.equal(detectTextDirection('API١٢٣٤'), 'ltr')
+  assert.equal(detectTextDirection('سلام1234', 'ltr'), 'rtl')
+  assert.equal(detectTextDirection('Ⅻ'), 'ltr')
+})

--- a/src/lib/text-direction.ts
+++ b/src/lib/text-direction.ts
@@ -1,5 +1,6 @@
 export type TextDirection = 'rtl' | 'ltr'
 
+const DECIMAL_DIGIT = /\p{Decimal_Number}/u
 const STRONG_RTL = /[\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}]/u
 const STRONG_LTR =
   /[\p{Script=Latin}\p{Script=Cyrillic}\p{Script=Greek}\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u
@@ -13,6 +14,8 @@ export function detectTextDirection(text: string, fallback: TextDirection = 'rtl
     let ltrCharacters = 0
 
     for (const character of word) {
+      // Persian and Arabic-Indic digits have an RTL script, but are not strong RTL letters.
+      if (DECIMAL_DIGIT.test(character)) continue
       if (STRONG_RTL.test(character)) rtlCharacters += 1
       else if (STRONG_LTR.test(character)) ltrCharacters += 1
     }


### PR DESCRIPTION
## What changed

Exclude Unicode decimal digits from directional word voting in `detectTextDirection`. Persian and Arabic-Indic digits have an Arabic script property, so the existing script check counts them as RTL letters:

```ts
detectTextDirection('Hello ۱۲۳ ۴۵۶') // before: rtl; after: ltr
detectTextDirection('API۱۲۳۴')       // before: rtl; after: ltr
detectTextDirection('۱۲۳', 'ltr')    // before: rtl; after: ltr
```

The existing dominant-word policy, supported script lists and caller fallback remain unchanged. Decimal digits are ignored for voting; this deliberately does not remove all Unicode Number characters (for example, the Latin Roman numeral `Ⅻ` retains its existing LTR classification). No dependency, UI/layout, stored-text or model-prompt changes.

## Verification

Windows, Node 25.2.1, pnpm 10.27.0. Dependencies installed from the lockfile with install scripts disabled.

- Before the fix: the two new regression tests fail; the existing three pass.
- After the fix: `pnpm exec tsx --test src/lib/text-direction.test.ts` — **5/5 pass**.
- `pnpm typecheck` — pass.
- `pnpm exec prettier --check src/lib/text-direction.ts src/lib/text-direction.test.ts` and `git diff --check` — pass.
- Full `pnpm test` on unchanged upstream `7e87b61`: **263 passed, 9 failed, 1 skipped** (273 tests).
- Full `pnpm test` with this patch: **265 passed, 9 failed, 1 skipped** (275 tests).
- Compared failure names: the same nine tests fail in both worktrees. They concern command/file policy assertions, Windows symlink permissions and SQLite file cleanup. No direction-helper test fails after the change. I am not claiming the full suite is green or that the Electron UI was manually tested.

## Context

I found this while checking mixed Persian/English rendering cases for [BidiLens](https://github.com/CodeinScrubs/BidiLens), which I maintain. The fix here is native and independent of BidiLens; a new dependency is unnecessary for this issue.
